### PR TITLE
fix: prevent duplicate disbursements for same beneficiary and purpose

### DIFF
--- a/src/aid_registry.rs
+++ b/src/aid_registry.rs
@@ -222,6 +222,18 @@ impl AidRegistry {
             }
         }
         
+        // Prevent duplicate disbursements: same beneficiary + same purpose in this fund
+        let disbursement_key = Symbol::new(&env, &format!("disbursements_{}", fund_id));
+        let existing_disbursements: Map<String, DisbursementRecord> = env.storage().instance()
+            .get(&disbursement_key)
+            .unwrap_or(Map::new(&env));
+        
+        for (_, record) in existing_disbursements.iter() {
+            if record.beneficiary == beneficiary && record.purpose == purpose {
+                panic_with_error!(&env, "Duplicate disbursement: beneficiary already received funds for this purpose");
+            }
+        }
+        
         // Create disbursement record
         let disbursement_id = format!("{}_{}", fund_id, env.ledger().timestamp());
         let disbursement = DisbursementRecord {
@@ -233,13 +245,12 @@ impl AidRegistry {
             purpose,
             approved_by: approvers,
             transaction_hash: String::from_str(&env, ""), // Will be set after transaction
+            trigger_id: None,
+            is_auto_released: false,
         };
         
-        // Store disbursement
-        let disbursement_key = Symbol::new(&env, &format!("disbursements_{}", fund_id));
-        let mut disbursements: Map<String, DisbursementRecord> = env.storage().instance()
-            .get(&disbursement_key)
-            .unwrap_or(Map::new(&env));
+        // Store disbursement (reuse already-loaded map from duplicate check)
+        let mut disbursements = existing_disbursements;
         
         disbursements.set(disbursement_id.clone(), disbursement);
         env.storage().instance().set(&disbursement_key, &disbursements);


### PR DESCRIPTION
Fixes #17

## Summary
Adds duplicate disbursement prevention to the `submit_disbursement` function in `aid_registry.rs`. The same beneficiary can no longer receive multiple disbursements for the same purpose within a single fund.

## Changes
- Added duplicate check that iterates existing disbursement records for the fund and rejects if the same beneficiary + purpose combination already exists
- Added missing `trigger_id` and `is_auto_released` fields to the `DisbursementRecord` constructor (compilation fix)
- Reused already-loaded disbursement map to avoid redundant storage reads

## Testing
- The duplicate check runs before the disbursement record is created
- If a matching beneficiary + purpose pair is found, the transaction panics with: `"Duplicate disbursement: beneficiary already received funds for this purpose"`
- Different beneficiaries or different purposes for the same beneficiary are still allowed

## Related Issues
Fixes #17