### PR TITLE
feat(validation): comprehensive client-side form validation across all forms

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,9 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/ui/src'],
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+  transform: { '^.+\\.tsx?$': ['ts-jest', { tsconfig: { jsx: 'react', esModuleInterop: true } }] },
+};

--- a/ui/src/__tests__/validators.test.ts
+++ b/ui/src/__tests__/validators.test.ts
@@ -1,0 +1,165 @@
+import {
+  required, minLength, maxLength, isPositiveNumber, isInteger,
+  minValue, maxValue, stellarAddress, disasterType, businessType,
+  tokenType, identifier, futureDate, latitude, longitude,
+  commaSeparatedRequired, compose,
+} from '../validation/validators';
+
+describe('required', () => {
+  const v = required('Field');
+  it('returns error for empty string', () => expect(v('')).toBeTruthy());
+  it('returns error for whitespace-only', () => expect(v('   ')).toBeTruthy());
+  it('returns null for valid value', () => expect(v('hello')).toBeNull());
+});
+
+describe('minLength', () => {
+  const v = minLength(3, 'Name');
+  it('returns error when too short', () => expect(v('ab')).toBeTruthy());
+  it('returns null when empty (defer to required)', () => expect(v('')).toBeNull());
+  it('returns null when long enough', () => expect(v('abc')).toBeNull());
+});
+
+describe('maxLength', () => {
+  const v = maxLength(5, 'Name');
+  it('returns error when too long', () => expect(v('abcdef')).toBeTruthy());
+  it('returns null when within limit', () => expect(v('abc')).toBeNull());
+  it('returns null when empty', () => expect(v('')).toBeNull());
+});
+
+describe('isPositiveNumber', () => {
+  const v = isPositiveNumber('Amount');
+  it('returns error for zero', () => expect(v('0')).toBeTruthy());
+  it('returns error for negative', () => expect(v('-5')).toBeTruthy());
+  it('returns error for non-numeric', () => expect(v('abc')).toBeTruthy());
+  it('returns null for positive number', () => expect(v('100')).toBeNull());
+  it('returns null for empty (defer to required)', () => expect(v('')).toBeNull());
+  it('returns error for NaN string', () => expect(v('NaN')).toBeTruthy());
+  it('returns error for Infinity', () => expect(v('Infinity')).toBeTruthy());
+});
+
+describe('isInteger', () => {
+  const v = isInteger('Value');
+  it('returns error for decimal', () => expect(v('1.5')).toBeTruthy());
+  it('returns null for whole number', () => expect(v('3')).toBeNull());
+  it('returns null for empty', () => expect(v('')).toBeNull());
+});
+
+describe('minValue', () => {
+  const v = minValue(5, 'Count');
+  it('returns error below min', () => expect(v('4')).toBeTruthy());
+  it('returns null at min', () => expect(v('5')).toBeNull());
+  it('returns null above min', () => expect(v('10')).toBeNull());
+  it('returns null for empty', () => expect(v('')).toBeNull());
+});
+
+describe('maxValue', () => {
+  const v = maxValue(10, 'Count');
+  it('returns error above max', () => expect(v('11')).toBeTruthy());
+  it('returns null at max', () => expect(v('10')).toBeNull());
+  it('returns null for empty', () => expect(v('')).toBeNull());
+});
+
+describe('stellarAddress', () => {
+  const valid = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA';
+  it('returns null for valid G... address', () => expect(stellarAddress(valid)).toBeNull());
+  it('returns error for wrong prefix', () =>
+    expect(stellarAddress('BAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA')).toBeTruthy());
+  it('returns error for too short', () =>
+    expect(stellarAddress('GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOC')).toBeTruthy());
+  it('returns error for lowercase', () =>
+    expect(stellarAddress('gaazi4tcr3ty5ojhctjc2a4qsy6cjwjh5iajtgkin2er7lbnvkoccwna')).toBeTruthy());
+  it('returns null for empty (defer to required)', () => expect(stellarAddress('')).toBeNull());
+  it('returns error for whitespace-padded invalid', () =>
+    expect(stellarAddress('  GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOC  ')).toBeTruthy());
+});
+
+describe('disasterType', () => {
+  it('returns null for valid type', () => expect(disasterType('earthquake')).toBeNull());
+  it('returns error for invalid type', () => expect(disasterType('tsunami')).toBeTruthy());
+  it('returns null for empty', () => expect(disasterType('')).toBeNull());
+  (['earthquake', 'flood', 'hurricane', 'wildfire', 'drought'] as const).forEach(t =>
+    it(`accepts ${t}`, () => expect(disasterType(t)).toBeNull())
+  );
+});
+
+describe('businessType', () => {
+  it('returns null for valid type', () => expect(businessType('grocery')).toBeNull());
+  it('returns error for invalid type', () => expect(businessType('bakery')).toBeTruthy());
+  it('returns null for empty', () => expect(businessType('')).toBeNull());
+});
+
+describe('tokenType', () => {
+  it('returns null for XLM', () => expect(tokenType('XLM')).toBeNull());
+  it('returns null for USDC', () => expect(tokenType('USDC')).toBeNull());
+  it('returns null for EURT', () => expect(tokenType('EURT')).toBeNull());
+  it('returns error for unknown token', () => expect(tokenType('BTC')).toBeTruthy());
+  it('returns null for empty', () => expect(tokenType('')).toBeNull());
+});
+
+describe('identifier', () => {
+  const v = identifier('ID');
+  it('returns null for valid id', () => expect(v('fund_001')).toBeNull());
+  it('returns null for alphanumeric with hyphens', () => expect(v('fund-2024')).toBeNull());
+  it('returns error for spaces', () => expect(v('fund 001')).toBeTruthy());
+  it('returns error for special chars', () => expect(v('fund@001')).toBeTruthy());
+  it('returns error for empty string', () => expect(v('')).toBeNull()); // empty defers to required
+  it('returns error for >64 chars', () => expect(v('a'.repeat(65))).toBeTruthy());
+});
+
+describe('futureDate', () => {
+  const v = futureDate('Date');
+  it('returns error for past date', () => expect(v('2020-01-01T00:00')).toBeTruthy());
+  it('returns error for invalid date string', () => expect(v('not-a-date')).toBeTruthy());
+  it('returns null for empty', () => expect(v('')).toBeNull());
+  it('returns null for future date', () => {
+    const future = new Date(Date.now() + 86400000).toISOString().slice(0, 16);
+    expect(v(future)).toBeNull();
+  });
+});
+
+describe('latitude', () => {
+  it('returns null for valid latitude', () => expect(latitude('45.0')).toBeNull());
+  it('returns error for >90', () => expect(latitude('91')).toBeTruthy());
+  it('returns error for <-90', () => expect(latitude('-91')).toBeTruthy());
+  it('returns error for non-numeric', () => expect(latitude('abc')).toBeTruthy());
+  it('returns null for empty', () => expect(latitude('')).toBeNull());
+  it('returns null for boundary -90', () => expect(latitude('-90')).toBeNull());
+  it('returns null for boundary 90', () => expect(latitude('90')).toBeNull());
+});
+
+describe('longitude', () => {
+  it('returns null for valid longitude', () => expect(longitude('120.5')).toBeNull());
+  it('returns error for >180', () => expect(longitude('181')).toBeTruthy());
+  it('returns error for <-180', () => expect(longitude('-181')).toBeTruthy());
+  it('returns null for boundary values', () => {
+    expect(longitude('-180')).toBeNull();
+    expect(longitude('180')).toBeNull();
+  });
+});
+
+describe('commaSeparatedRequired', () => {
+  const v = commaSeparatedRequired('Factors');
+  it('returns null for valid comma list', () => expect(v('a, b, c')).toBeNull());
+  it('returns null for single item', () => expect(v('item')).toBeNull());
+  it('returns null for empty (defer to required)', () => expect(v('')).toBeNull());
+  it('returns error for only commas/spaces', () => expect(v(', , ,')).toBeTruthy());
+});
+
+describe('compose', () => {
+  it('returns first error', () => {
+    const v = compose(required('F'), minLength(5, 'F'));
+    expect(v('')).toMatch(/required/i);
+  });
+  it('returns second error when first passes', () => {
+    const v = compose(required('F'), minLength(5, 'F'));
+    expect(v('ab')).toMatch(/at least/i);
+  });
+  it('returns null when all pass', () => {
+    const v = compose(required('F'), minLength(2, 'F'));
+    expect(v('hello')).toBeNull();
+  });
+  it('handles whitespace-only input with required', () => {
+    const v = compose(required('F'), minLength(2, 'F'));
+    expect(v('   ')).toBeTruthy();
+  });
+});

--- a/ui/src/components/BeneficiaryRegistration.tsx
+++ b/ui/src/components/BeneficiaryRegistration.tsx
@@ -1,6 +1,19 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { BeneficiaryClient, BeneficiaryProfile, VerificationFactor, NetworkConfig } from '../../sdk/src/types';
 import {
+  useFormValidation,
+  FieldError,
+  compose,
+  required,
+  minLength,
+  maxLength,
+  identifier,
+  isInteger,
+  minValue,
+  stellarAddress,
+  commaSeparatedRequired,
+} from '../validation';
+import {
   SkeletonList,
   StatusMessage,
   EmptyState,
@@ -37,6 +50,24 @@ export const BeneficiaryRegistration: React.FC<BeneficiaryRegistrationProps> = (
     beneficiaryId: '', verifierKey: '', providedFactors: '',
   });
 
+  const regValidation = useFormValidation<typeof registrationForm>({
+    beneficiaryId: compose(required('Beneficiary ID'), identifier('Beneficiary ID')),
+    name: compose(required('Full Name'), minLength(2, 'Full Name'), maxLength(100, 'Full Name')),
+    disasterId: compose(required('Disaster ID'), identifier('Disaster ID')),
+    location: compose(required('Location'), minLength(2, 'Location'), maxLength(200, 'Location')),
+    walletAddress: compose(required('Wallet Address'), stellarAddress),
+    familySize: compose(required('Family Size'), isInteger('Family Size'), minValue(1, 'Family Size')),
+    possessionFactors: compose(required('Possession Factors'), commaSeparatedRequired('Possession Factors')),
+    behavioralFactors: compose(required('Behavioral Factors'), commaSeparatedRequired('Behavioral Factors')),
+    socialFactors: compose(required('Social Factors'), commaSeparatedRequired('Social Factors')),
+  });
+
+  const verifyValidation = useFormValidation<typeof verificationForm>({
+    beneficiaryId: compose(required('Beneficiary ID'), identifier('Beneficiary ID')),
+    verifierKey: required('Verifier Key'),
+    providedFactors: compose(required('Provided Factors'), commaSeparatedRequired('Provided Factors')),
+  });
+
   const [ussdSession, setUssdSession] = useState({
     sessionId: '', phoneNumber: '', currentStep: 'welcome', response: '',
   });
@@ -58,6 +89,7 @@ export const BeneficiaryRegistration: React.FC<BeneficiaryRegistrationProps> = (
 
   const handleRegistration = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!regValidation.validateAll(registrationForm as Record<keyof typeof registrationForm, string>)) return;
     setSubmitting(true);
     setSubmitStatus(null);
     try {
@@ -77,6 +109,7 @@ export const BeneficiaryRegistration: React.FC<BeneficiaryRegistrationProps> = (
       setRecoveryCodes(codes);
       setShowRegistrationForm(false);
       setRegistrationForm({ beneficiaryId: '', name: '', disasterId: '', location: '', walletAddress: '', familySize: '1', specialNeeds: '', possessionFactors: '', behavioralFactors: '', socialFactors: '' });
+      regValidation.reset();
       setSubmitStatus({ type: 'success', message: 'Beneficiary registered successfully. Save your recovery codes.' });
       loadBeneficiaries();
     } catch {
@@ -88,6 +121,7 @@ export const BeneficiaryRegistration: React.FC<BeneficiaryRegistrationProps> = (
 
   const handleVerification = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!verifyValidation.validateAll(verificationForm as Record<keyof typeof verificationForm, string>)) return;
     setSubmitting(true);
     setSubmitStatus(null);
     try {
@@ -102,6 +136,7 @@ export const BeneficiaryRegistration: React.FC<BeneficiaryRegistrationProps> = (
       );
       setShowVerificationForm(false);
       setVerificationForm({ beneficiaryId: '', verifierKey: '', providedFactors: '' });
+      verifyValidation.reset();
       loadBeneficiaries();
     } catch {
       setSubmitStatus({ type: 'error', message: 'Failed to verify beneficiary.' });
@@ -168,42 +203,66 @@ export const BeneficiaryRegistration: React.FC<BeneficiaryRegistrationProps> = (
             <h2 className="text-xl font-semibold mb-4">Register New Beneficiary</h2>
             <form onSubmit={handleRegistration} className="space-y-4" aria-label="Beneficiary registration form">
               <div className="grid grid-cols-2 gap-4">
-                <input type="text" placeholder="Beneficiary ID" value={registrationForm.beneficiaryId} required aria-label="Beneficiary ID"
-                  onChange={e => setRegistrationForm({ ...registrationForm, beneficiaryId: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" />
-                <input type="text" placeholder="Full Name" value={registrationForm.name} required aria-label="Full Name"
-                  onChange={e => setRegistrationForm({ ...registrationForm, name: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                <div>
+                  <input type="text" placeholder="Beneficiary ID" value={registrationForm.beneficiaryId} aria-label="Beneficiary ID" aria-describedby="reg-beneficiaryId-error"
+                    onChange={e => { setRegistrationForm({ ...registrationForm, beneficiaryId: e.target.value }); regValidation.validateField('beneficiaryId', e.target.value); }}
+                    onBlur={e => regValidation.validateField('beneficiaryId', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${regValidation.touched.beneficiaryId && regValidation.errors.beneficiaryId ? 'border-red-500' : ''}`} />
+                  <FieldError id="reg-beneficiaryId-error" error={regValidation.touched.beneficiaryId ? regValidation.errors.beneficiaryId : null} />
+                </div>
+                <div>
+                  <input type="text" placeholder="Full Name" value={registrationForm.name} aria-label="Full Name" aria-describedby="reg-name-error"
+                    onChange={e => { setRegistrationForm({ ...registrationForm, name: e.target.value }); regValidation.validateField('name', e.target.value); }}
+                    onBlur={e => regValidation.validateField('name', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${regValidation.touched.name && regValidation.errors.name ? 'border-red-500' : ''}`} />
+                  <FieldError id="reg-name-error" error={regValidation.touched.name ? regValidation.errors.name : null} />
+                </div>
               </div>
               <div className="grid grid-cols-2 gap-4">
-                <input type="text" placeholder="Disaster ID" value={registrationForm.disasterId} required aria-label="Disaster ID"
-                  onChange={e => setRegistrationForm({ ...registrationForm, disasterId: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" />
-                <input type="text" placeholder="Location" value={registrationForm.location} required aria-label="Location"
-                  onChange={e => setRegistrationForm({ ...registrationForm, location: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                <div>
+                  <input type="text" placeholder="Disaster ID" value={registrationForm.disasterId} aria-label="Disaster ID" aria-describedby="reg-disasterId-error"
+                    onChange={e => { setRegistrationForm({ ...registrationForm, disasterId: e.target.value }); regValidation.validateField('disasterId', e.target.value); }}
+                    onBlur={e => regValidation.validateField('disasterId', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${regValidation.touched.disasterId && regValidation.errors.disasterId ? 'border-red-500' : ''}`} />
+                  <FieldError id="reg-disasterId-error" error={regValidation.touched.disasterId ? regValidation.errors.disasterId : null} />
+                </div>
+                <div>
+                  <input type="text" placeholder="Location" value={registrationForm.location} aria-label="Location" aria-describedby="reg-location-error"
+                    onChange={e => { setRegistrationForm({ ...registrationForm, location: e.target.value }); regValidation.validateField('location', e.target.value); }}
+                    onBlur={e => regValidation.validateField('location', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${regValidation.touched.location && regValidation.errors.location ? 'border-red-500' : ''}`} />
+                  <FieldError id="reg-location-error" error={regValidation.touched.location ? regValidation.errors.location : null} />
+                </div>
               </div>
               <div className="grid grid-cols-2 gap-4">
-                <input type="text" placeholder="Wallet Address" value={registrationForm.walletAddress} required aria-label="Wallet Address"
-                  onChange={e => setRegistrationForm({ ...registrationForm, walletAddress: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" />
-                <input type="number" placeholder="Family Size" value={registrationForm.familySize} required min="1" aria-label="Family Size"
-                  onChange={e => setRegistrationForm({ ...registrationForm, familySize: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                <div>
+                  <input type="text" placeholder="Wallet Address" value={registrationForm.walletAddress} aria-label="Wallet Address" aria-describedby="reg-walletAddress-error"
+                    onChange={e => { setRegistrationForm({ ...registrationForm, walletAddress: e.target.value }); regValidation.validateField('walletAddress', e.target.value); }}
+                    onBlur={e => regValidation.validateField('walletAddress', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${regValidation.touched.walletAddress && regValidation.errors.walletAddress ? 'border-red-500' : ''}`} />
+                  <FieldError id="reg-walletAddress-error" error={regValidation.touched.walletAddress ? regValidation.errors.walletAddress : null} />
+                </div>
+                <div>
+                  <input type="number" placeholder="Family Size" value={registrationForm.familySize} min="1" aria-label="Family Size" aria-describedby="reg-familySize-error"
+                    onChange={e => { setRegistrationForm({ ...registrationForm, familySize: e.target.value }); regValidation.validateField('familySize', e.target.value); }}
+                    onBlur={e => regValidation.validateField('familySize', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${regValidation.touched.familySize && regValidation.errors.familySize ? 'border-red-500' : ''}`} />
+                  <FieldError id="reg-familySize-error" error={regValidation.touched.familySize ? regValidation.errors.familySize : null} />
+                </div>
               </div>
               {[
-                { label: 'Special Needs (comma-separated)', field: 'specialNeeds', placeholder: 'e.g., medical, mobility' },
-                { label: 'Possession Factors (comma-separated)', field: 'possessionFactors', placeholder: 'e.g., phone_number, id_card', required: true },
-                { label: 'Behavioral Factors (comma-separated)', field: 'behavioralFactors', placeholder: 'e.g., signature_pattern', required: true },
-                { label: 'Social Factors (comma-separated)', field: 'socialFactors', placeholder: 'e.g., community_leader_vouch', required: true },
-              ].map(({ label, field, placeholder, required }) => (
+                { label: 'Special Needs (comma-separated)', field: 'specialNeeds' as const, placeholder: 'e.g., medical, mobility', required: false },
+                { label: 'Possession Factors (comma-separated)', field: 'possessionFactors' as const, placeholder: 'e.g., phone_number, id_card', required: true },
+                { label: 'Behavioral Factors (comma-separated)', field: 'behavioralFactors' as const, placeholder: 'e.g., signature_pattern', required: true },
+                { label: 'Social Factors (comma-separated)', field: 'socialFactors' as const, placeholder: 'e.g., community_leader_vouch', required: true },
+              ].map(({ label, field, placeholder }) => (
                 <div key={field}>
                   <label className="block text-sm font-medium mb-1">{label}</label>
-                  <input type="text" placeholder={placeholder} required={required}
-                    value={(registrationForm as Record<string, string>)[field]}
-                    onChange={e => setRegistrationForm({ ...registrationForm, [field]: e.target.value })}
-                    className="w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
-                    aria-label={label} />
+                  <input type="text" placeholder={placeholder} value={registrationForm[field]} aria-label={label} aria-describedby={`reg-${field}-error`}
+                    onChange={e => { setRegistrationForm({ ...registrationForm, [field]: e.target.value }); regValidation.validateField(field, e.target.value); }}
+                    onBlur={e => regValidation.validateField(field, e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${regValidation.touched[field] && regValidation.errors[field] ? 'border-red-500' : ''}`} />
+                  <FieldError id={`reg-${field}-error`} error={regValidation.touched[field] ? regValidation.errors[field] : null} />
                 </div>
               ))}
               <div className="flex gap-3">
@@ -226,19 +285,28 @@ export const BeneficiaryRegistration: React.FC<BeneficiaryRegistrationProps> = (
             <h2 className="text-xl font-semibold mb-4">Verify Beneficiary Identity</h2>
             <form onSubmit={handleVerification} className="space-y-4" aria-label="Verification form">
               <div className="grid grid-cols-2 gap-4">
-                <input type="text" placeholder="Beneficiary ID" value={verificationForm.beneficiaryId} required aria-label="Beneficiary ID"
-                  onChange={e => setVerificationForm({ ...verificationForm, beneficiaryId: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-green-500" />
-                <input type="password" placeholder="Verifier Key" value={verificationForm.verifierKey} required aria-label="Verifier Key"
-                  onChange={e => setVerificationForm({ ...verificationForm, verifierKey: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-green-500" />
+                <div>
+                  <input type="text" placeholder="Beneficiary ID" value={verificationForm.beneficiaryId} aria-label="Beneficiary ID" aria-describedby="ver-beneficiaryId-error"
+                    onChange={e => { setVerificationForm({ ...verificationForm, beneficiaryId: e.target.value }); verifyValidation.validateField('beneficiaryId', e.target.value); }}
+                    onBlur={e => verifyValidation.validateField('beneficiaryId', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-green-500 ${verifyValidation.touched.beneficiaryId && verifyValidation.errors.beneficiaryId ? 'border-red-500' : ''}`} />
+                  <FieldError id="ver-beneficiaryId-error" error={verifyValidation.touched.beneficiaryId ? verifyValidation.errors.beneficiaryId : null} />
+                </div>
+                <div>
+                  <input type="password" placeholder="Verifier Key" value={verificationForm.verifierKey} aria-label="Verifier Key" aria-describedby="ver-verifierKey-error"
+                    onChange={e => { setVerificationForm({ ...verificationForm, verifierKey: e.target.value }); verifyValidation.validateField('verifierKey', e.target.value); }}
+                    onBlur={e => verifyValidation.validateField('verifierKey', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-green-500 ${verifyValidation.touched.verifierKey && verifyValidation.errors.verifierKey ? 'border-red-500' : ''}`} />
+                  <FieldError id="ver-verifierKey-error" error={verifyValidation.touched.verifierKey ? verifyValidation.errors.verifierKey : null} />
+                </div>
               </div>
               <div>
                 <label className="block text-sm font-medium mb-1">Provided Factors (comma-separated)</label>
-                <input type="text" placeholder="e.g., phone_number, signature_pattern" required aria-label="Provided Factors"
-                  value={verificationForm.providedFactors}
-                  onChange={e => setVerificationForm({ ...verificationForm, providedFactors: e.target.value })}
-                  className="w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-green-500" />
+                <input type="text" placeholder="e.g., phone_number, signature_pattern" value={verificationForm.providedFactors} aria-label="Provided Factors" aria-describedby="ver-providedFactors-error"
+                  onChange={e => { setVerificationForm({ ...verificationForm, providedFactors: e.target.value }); verifyValidation.validateField('providedFactors', e.target.value); }}
+                  onBlur={e => verifyValidation.validateField('providedFactors', e.target.value)}
+                  className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-green-500 ${verifyValidation.touched.providedFactors && verifyValidation.errors.providedFactors ? 'border-red-500' : ''}`} />
+                <FieldError id="ver-providedFactors-error" error={verifyValidation.touched.providedFactors ? verifyValidation.errors.providedFactors : null} />
               </div>
               <div className="flex gap-3">
                 <LoadingButton type="submit" loading={submitting} loadingLabel="Verifying…"

--- a/ui/src/components/EmergencyDeployer.tsx
+++ b/ui/src/components/EmergencyDeployer.tsx
@@ -1,6 +1,20 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { AidClient, EmergencyFund, NetworkConfig } from '../../sdk/src/types';
 import {
+  useFormValidation,
+  FieldError,
+  compose,
+  required,
+  minLength,
+  maxLength,
+  identifier,
+  isPositiveNumber,
+  minValue,
+  disasterType,
+  futureDate,
+  isInteger,
+} from '../validation';
+import {
   SkeletonList,
   SkeletonCard,
   StatusMessage,
@@ -42,6 +56,24 @@ export const EmergencyDeployer: React.FC<EmergencyDeployerProps> = ({
     requiredSignatures: '1',
   });
 
+  const fundValidation = useFormValidation<typeof fundForm>({
+    fundId: compose(required('Fund ID'), identifier('Fund ID')),
+    name: compose(required('Fund Name'), minLength(2, 'Fund Name'), maxLength(100, 'Fund Name')),
+    description: compose(required('Description'), minLength(10, 'Description'), maxLength(500, 'Description')),
+    totalAmount: compose(required('Total Amount'), isPositiveNumber('Total Amount'), minValue(1, 'Total Amount')),
+    disasterType: compose(required('Disaster Type'), disasterType),
+    geographicScope: compose(required('Geographic Scope'), minLength(2, 'Geographic Scope'), maxLength(200, 'Geographic Scope')),
+    expiresAt: compose(required('Expiry Date'), futureDate('Expiry Date')),
+    requiredSignatures: compose(required('Required Signatures'), isInteger('Required Signatures'), minValue(1, 'Required Signatures')),
+  });
+
+  const rapidValidation = useFormValidation<typeof rapidForm>({
+    disasterId: compose(required('Disaster ID'), identifier('Disaster ID')),
+    disasterType: compose(required('Disaster Type'), disasterType),
+    affectedArea: compose(required('Affected Area'), minLength(2, 'Affected Area'), maxLength(200, 'Affected Area')),
+    totalBudget: compose(required('Total Budget'), isPositiveNumber('Total Budget'), minValue(1, 'Total Budget')),
+  });
+
   const [rapidForm, setRapidForm] = useState({
     disasterId: '',
     disasterType: '',
@@ -75,6 +107,7 @@ export const EmergencyDeployer: React.FC<EmergencyDeployerProps> = ({
 
   const handleCreateFund = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!fundValidation.validateAll(fundForm as Record<keyof typeof fundForm, string>)) return;
     setSubmitting(true);
     setSubmitStatus(null);
     try {
@@ -101,6 +134,7 @@ export const EmergencyDeployer: React.FC<EmergencyDeployerProps> = ({
         expiresAt: '',
         requiredSignatures: '1',
       });
+      fundValidation.reset();
       setSubmitStatus({ type: 'success', message: 'Emergency fund created successfully.' });
       loadActiveFunds();
     } catch (error) {
@@ -113,6 +147,7 @@ export const EmergencyDeployer: React.FC<EmergencyDeployerProps> = ({
 
   const handleRapidDeployment = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!rapidValidation.validateAll(rapidForm as Record<keyof typeof rapidForm, string>)) return;
     setSubmitting(true);
     setSubmitStatus(null);
     try {
@@ -126,6 +161,7 @@ export const EmergencyDeployer: React.FC<EmergencyDeployerProps> = ({
       );
       setShowRapidForm(false);
       setRapidForm({ ...rapidForm, disasterId: '', disasterType: '', affectedArea: '', totalBudget: '' });
+      rapidValidation.reset();
       setSubmitStatus({ type: 'success', message: `Created ${fundIds.length} emergency funds for rapid response.` });
       loadActiveFunds();
     } catch (error) {
@@ -224,77 +260,105 @@ export const EmergencyDeployer: React.FC<EmergencyDeployerProps> = ({
             <h2 className="text-xl font-semibold mb-4">Create Emergency Fund</h2>
             <form onSubmit={handleCreateFund} className="space-y-4" aria-label="Create emergency fund form">
               <div className="grid grid-cols-2 gap-4">
-                <input
-                  type="text"
-                  placeholder="Fund ID"
-                  value={fundForm.fundId}
-                  onChange={(e) => setFundForm({ ...fundForm, fundId: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  required
-                  aria-label="Fund ID"
-                />
-                <input
-                  type="text"
-                  placeholder="Fund Name"
-                  value={fundForm.name}
-                  onChange={(e) => setFundForm({ ...fundForm, name: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  required
-                  aria-label="Fund Name"
-                />
+                <div>
+                  <input
+                    type="text"
+                    placeholder="Fund ID"
+                    value={fundForm.fundId}
+                    onChange={(e) => { setFundForm({ ...fundForm, fundId: e.target.value }); fundValidation.validateField('fundId', e.target.value); }}
+                    onBlur={(e) => fundValidation.validateField('fundId', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${fundValidation.touched.fundId && fundValidation.errors.fundId ? 'border-red-500' : ''}`}
+                    aria-label="Fund ID"
+                    aria-describedby="fundId-error"
+                  />
+                  <FieldError id="fundId-error" error={fundValidation.touched.fundId ? fundValidation.errors.fundId : null} />
+                </div>
+                <div>
+                  <input
+                    type="text"
+                    placeholder="Fund Name"
+                    value={fundForm.name}
+                    onChange={(e) => { setFundForm({ ...fundForm, name: e.target.value }); fundValidation.validateField('name', e.target.value); }}
+                    onBlur={(e) => fundValidation.validateField('name', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${fundValidation.touched.name && fundValidation.errors.name ? 'border-red-500' : ''}`}
+                    aria-label="Fund Name"
+                    aria-describedby="name-error"
+                  />
+                  <FieldError id="name-error" error={fundValidation.touched.name ? fundValidation.errors.name : null} />
+                </div>
               </div>
-              <textarea
-                placeholder="Description"
-                value={fundForm.description}
-                onChange={(e) => setFundForm({ ...fundForm, description: e.target.value })}
-                className="w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
-                rows={3}
-                required
-                aria-label="Description"
-              />
-              <div className="grid grid-cols-2 gap-4">
-                <input
-                  type="number"
-                  placeholder="Total Amount"
-                  value={fundForm.totalAmount}
-                  onChange={(e) => setFundForm({ ...fundForm, totalAmount: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  required
-                  aria-label="Total Amount"
+              <div>
+                <textarea
+                  placeholder="Description"
+                  value={fundForm.description}
+                  onChange={(e) => { setFundForm({ ...fundForm, description: e.target.value }); fundValidation.validateField('description', e.target.value); }}
+                  onBlur={(e) => fundValidation.validateField('description', e.target.value)}
+                  className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${fundValidation.touched.description && fundValidation.errors.description ? 'border-red-500' : ''}`}
+                  rows={3}
+                  aria-label="Description"
+                  aria-describedby="description-error"
                 />
-                <select
-                  value={fundForm.disasterType}
-                  onChange={(e) => setFundForm({ ...fundForm, disasterType: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  required
-                  aria-label="Disaster Type"
-                >
-                  <option value="">Select Disaster Type</option>
-                  <option value="earthquake">Earthquake</option>
-                  <option value="flood">Flood</option>
-                  <option value="hurricane">Hurricane</option>
-                  <option value="wildfire">Wildfire</option>
-                  <option value="drought">Drought</option>
-                </select>
+                <FieldError id="description-error" error={fundValidation.touched.description ? fundValidation.errors.description : null} />
               </div>
               <div className="grid grid-cols-2 gap-4">
-                <input
-                  type="text"
-                  placeholder="Geographic Scope"
-                  value={fundForm.geographicScope}
-                  onChange={(e) => setFundForm({ ...fundForm, geographicScope: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  required
-                  aria-label="Geographic Scope"
-                />
-                <input
-                  type="datetime-local"
-                  value={fundForm.expiresAt}
-                  onChange={(e) => setFundForm({ ...fundForm, expiresAt: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  required
-                  aria-label="Expiry Date"
-                />
+                <div>
+                  <input
+                    type="number"
+                    placeholder="Total Amount"
+                    value={fundForm.totalAmount}
+                    onChange={(e) => { setFundForm({ ...fundForm, totalAmount: e.target.value }); fundValidation.validateField('totalAmount', e.target.value); }}
+                    onBlur={(e) => fundValidation.validateField('totalAmount', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${fundValidation.touched.totalAmount && fundValidation.errors.totalAmount ? 'border-red-500' : ''}`}
+                    aria-label="Total Amount"
+                    aria-describedby="totalAmount-error"
+                  />
+                  <FieldError id="totalAmount-error" error={fundValidation.touched.totalAmount ? fundValidation.errors.totalAmount : null} />
+                </div>
+                <div>
+                  <select
+                    value={fundForm.disasterType}
+                    onChange={(e) => { setFundForm({ ...fundForm, disasterType: e.target.value }); fundValidation.validateField('disasterType', e.target.value); }}
+                    onBlur={(e) => fundValidation.validateField('disasterType', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${fundValidation.touched.disasterType && fundValidation.errors.disasterType ? 'border-red-500' : ''}`}
+                    aria-label="Disaster Type"
+                    aria-describedby="disasterType-error"
+                  >
+                    <option value="">Select Disaster Type</option>
+                    <option value="earthquake">Earthquake</option>
+                    <option value="flood">Flood</option>
+                    <option value="hurricane">Hurricane</option>
+                    <option value="wildfire">Wildfire</option>
+                    <option value="drought">Drought</option>
+                  </select>
+                  <FieldError id="disasterType-error" error={fundValidation.touched.disasterType ? fundValidation.errors.disasterType : null} />
+                </div>
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <input
+                    type="text"
+                    placeholder="Geographic Scope"
+                    value={fundForm.geographicScope}
+                    onChange={(e) => { setFundForm({ ...fundForm, geographicScope: e.target.value }); fundValidation.validateField('geographicScope', e.target.value); }}
+                    onBlur={(e) => fundValidation.validateField('geographicScope', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${fundValidation.touched.geographicScope && fundValidation.errors.geographicScope ? 'border-red-500' : ''}`}
+                    aria-label="Geographic Scope"
+                    aria-describedby="geographicScope-error"
+                  />
+                  <FieldError id="geographicScope-error" error={fundValidation.touched.geographicScope ? fundValidation.errors.geographicScope : null} />
+                </div>
+                <div>
+                  <input
+                    type="datetime-local"
+                    value={fundForm.expiresAt}
+                    onChange={(e) => { setFundForm({ ...fundForm, expiresAt: e.target.value }); fundValidation.validateField('expiresAt', e.target.value); }}
+                    onBlur={(e) => fundValidation.validateField('expiresAt', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${fundValidation.touched.expiresAt && fundValidation.errors.expiresAt ? 'border-red-500' : ''}`}
+                    aria-label="Expiry Date"
+                    aria-describedby="expiresAt-error"
+                  />
+                  <FieldError id="expiresAt-error" error={fundValidation.touched.expiresAt ? fundValidation.errors.expiresAt : null} />
+                </div>
               </div>
               <div className="flex gap-3">
                 <LoadingButton
@@ -323,48 +387,64 @@ export const EmergencyDeployer: React.FC<EmergencyDeployerProps> = ({
             <h2 className="text-xl font-semibold mb-4">Rapid Disaster Response</h2>
             <form onSubmit={handleRapidDeployment} className="space-y-4" aria-label="Rapid disaster response form">
               <div className="grid grid-cols-2 gap-4">
-                <input
-                  type="text"
-                  placeholder="Disaster ID"
-                  value={rapidForm.disasterId}
-                  onChange={(e) => setRapidForm({ ...rapidForm, disasterId: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-red-500"
-                  required
-                  aria-label="Disaster ID"
-                />
-                <select
-                  value={rapidForm.disasterType}
-                  onChange={(e) => setRapidForm({ ...rapidForm, disasterType: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-red-500"
-                  required
-                  aria-label="Disaster Type"
-                >
-                  <option value="">Select Disaster Type</option>
-                  <option value="earthquake">Earthquake</option>
-                  <option value="flood">Flood</option>
-                  <option value="hurricane">Hurricane</option>
-                  <option value="wildfire">Wildfire</option>
-                </select>
+                <div>
+                  <input
+                    type="text"
+                    placeholder="Disaster ID"
+                    value={rapidForm.disasterId}
+                    onChange={(e) => { setRapidForm({ ...rapidForm, disasterId: e.target.value }); rapidValidation.validateField('disasterId', e.target.value); }}
+                    onBlur={(e) => rapidValidation.validateField('disasterId', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-red-500 ${rapidValidation.touched.disasterId && rapidValidation.errors.disasterId ? 'border-red-500' : ''}`}
+                    aria-label="Disaster ID"
+                    aria-describedby="rapid-disasterId-error"
+                  />
+                  <FieldError id="rapid-disasterId-error" error={rapidValidation.touched.disasterId ? rapidValidation.errors.disasterId : null} />
+                </div>
+                <div>
+                  <select
+                    value={rapidForm.disasterType}
+                    onChange={(e) => { setRapidForm({ ...rapidForm, disasterType: e.target.value }); rapidValidation.validateField('disasterType', e.target.value); }}
+                    onBlur={(e) => rapidValidation.validateField('disasterType', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-red-500 ${rapidValidation.touched.disasterType && rapidValidation.errors.disasterType ? 'border-red-500' : ''}`}
+                    aria-label="Disaster Type"
+                    aria-describedby="rapid-disasterType-error"
+                  >
+                    <option value="">Select Disaster Type</option>
+                    <option value="earthquake">Earthquake</option>
+                    <option value="flood">Flood</option>
+                    <option value="hurricane">Hurricane</option>
+                    <option value="wildfire">Wildfire</option>
+                  </select>
+                  <FieldError id="rapid-disasterType-error" error={rapidValidation.touched.disasterType ? rapidValidation.errors.disasterType : null} />
+                </div>
               </div>
               <div className="grid grid-cols-2 gap-4">
-                <input
-                  type="text"
-                  placeholder="Affected Area"
-                  value={rapidForm.affectedArea}
-                  onChange={(e) => setRapidForm({ ...rapidForm, affectedArea: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-red-500"
-                  required
-                  aria-label="Affected Area"
-                />
-                <input
-                  type="number"
-                  placeholder="Total Budget"
-                  value={rapidForm.totalBudget}
-                  onChange={(e) => setRapidForm({ ...rapidForm, totalBudget: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-red-500"
-                  required
-                  aria-label="Total Budget"
-                />
+                <div>
+                  <input
+                    type="text"
+                    placeholder="Affected Area"
+                    value={rapidForm.affectedArea}
+                    onChange={(e) => { setRapidForm({ ...rapidForm, affectedArea: e.target.value }); rapidValidation.validateField('affectedArea', e.target.value); }}
+                    onBlur={(e) => rapidValidation.validateField('affectedArea', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-red-500 ${rapidValidation.touched.affectedArea && rapidValidation.errors.affectedArea ? 'border-red-500' : ''}`}
+                    aria-label="Affected Area"
+                    aria-describedby="rapid-affectedArea-error"
+                  />
+                  <FieldError id="rapid-affectedArea-error" error={rapidValidation.touched.affectedArea ? rapidValidation.errors.affectedArea : null} />
+                </div>
+                <div>
+                  <input
+                    type="number"
+                    placeholder="Total Budget"
+                    value={rapidForm.totalBudget}
+                    onChange={(e) => { setRapidForm({ ...rapidForm, totalBudget: e.target.value }); rapidValidation.validateField('totalBudget', e.target.value); }}
+                    onBlur={(e) => rapidValidation.validateField('totalBudget', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-red-500 ${rapidValidation.touched.totalBudget && rapidValidation.errors.totalBudget ? 'border-red-500' : ''}`}
+                    aria-label="Total Budget"
+                    aria-describedby="rapid-totalBudget-error"
+                  />
+                  <FieldError id="rapid-totalBudget-error" error={rapidValidation.touched.totalBudget ? rapidValidation.errors.totalBudget : null} />
+                </div>
               </div>
               <div className="space-y-2">
                 <h3 className="font-semibold">Fund Categories:</h3>

--- a/ui/src/components/MerchantMap.tsx
+++ b/ui/src/components/MerchantMap.tsx
@@ -1,6 +1,21 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { MerchantClient, Merchant, Location, NetworkConfig } from '../../sdk/src/types';
 import {
+  useFormValidation,
+  FieldError,
+  compose,
+  required,
+  identifier,
+  minLength,
+  maxLength,
+  stellarAddress,
+  businessType,
+  latitude,
+  longitude,
+  isPositiveNumber,
+  minValue,
+} from '../validation';
+import {
   SkeletonList,
   StatusMessage,
   EmptyState,
@@ -33,6 +48,22 @@ export const MerchantMap: React.FC<MerchantMapProps> = ({ merchantClient, config
     location: { latitude: '', longitude: '', address: '', city: '', country: '', postalCode: '', facilityName: '', contactPerson: '' },
   });
 
+  type FlatOnboarding = { merchantId: string; name: string; businessType: string; contactInfo: string; stellarAddress: string; latitude: string; longitude: string; address: string; city: string; country: string; dailyLimit: string; monthlyLimit: string; };
+  const onboardValidation = useFormValidation<FlatOnboarding>({
+    merchantId: compose(required('Merchant ID'), identifier('Merchant ID')),
+    name: compose(required('Business Name'), minLength(2, 'Business Name'), maxLength(100, 'Business Name')),
+    businessType: compose(required('Business Type'), businessType),
+    contactInfo: compose(required('Contact Information'), minLength(2, 'Contact Information')),
+    stellarAddress: compose(required('Stellar Address'), stellarAddress),
+    latitude: compose(required('Latitude'), latitude),
+    longitude: compose(required('Longitude'), longitude),
+    address: compose(required('Address'), minLength(2, 'Address')),
+    city: compose(required('City'), minLength(2, 'City')),
+    country: compose(required('Country'), minLength(2, 'Country')),
+    dailyLimit: compose(required('Daily Limit'), isPositiveNumber('Daily Limit'), minValue(1, 'Daily Limit')),
+    monthlyLimit: compose(required('Monthly Limit'), isPositiveNumber('Monthly Limit'), minValue(1, 'Monthly Limit')),
+  });
+
   const loadMerchants = useCallback(async () => {
     setListLoading(true);
     setListError(null);
@@ -62,6 +93,8 @@ export const MerchantMap: React.FC<MerchantMapProps> = ({ merchantClient, config
 
   const handleOnboarding = async (e: React.FormEvent) => {
     e.preventDefault();
+    const flat = { ...onboardingForm, ...onboardingForm.location } as Record<string, string>;
+    if (!onboardValidation.validateAll(flat as never)) return;
     setSubmitting(true);
     setSubmitStatus(null);
     try {
@@ -84,6 +117,7 @@ export const MerchantMap: React.FC<MerchantMapProps> = ({ merchantClient, config
         acceptedTokens: 'XLM', dailyLimit: '1000', monthlyLimit: '10000',
         location: { latitude: '', longitude: '', address: '', city: '', country: '', postalCode: '', facilityName: '', contactPerson: '' },
       });
+      onboardValidation.reset();
       setSubmitStatus({ type: 'success', message: 'Merchant registered successfully. Awaiting verification.' });
       loadVerificationQueue();
     } catch {
@@ -174,34 +208,54 @@ export const MerchantMap: React.FC<MerchantMapProps> = ({ merchantClient, config
             <h2 className="text-xl font-semibold mb-4">Onboard New Merchant</h2>
             <form onSubmit={handleOnboarding} className="space-y-4" aria-label="Merchant onboarding form">
               <div className="grid grid-cols-2 gap-4">
-                <input type="text" placeholder="Merchant ID" value={onboardingForm.merchantId} required aria-label="Merchant ID"
-                  onChange={e => setOnboardingForm({ ...onboardingForm, merchantId: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" />
-                <input type="text" placeholder="Business Name" value={onboardingForm.name} required aria-label="Business Name"
-                  onChange={e => setOnboardingForm({ ...onboardingForm, name: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                <div>
+                  <input type="text" placeholder="Merchant ID" value={onboardingForm.merchantId} aria-label="Merchant ID" aria-describedby="mo-merchantId-error"
+                    onChange={e => { setOnboardingForm({ ...onboardingForm, merchantId: e.target.value }); onboardValidation.validateField('merchantId', e.target.value); }}
+                    onBlur={e => onboardValidation.validateField('merchantId', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${onboardValidation.touched.merchantId && onboardValidation.errors.merchantId ? 'border-red-500' : ''}`} />
+                  <FieldError id="mo-merchantId-error" error={onboardValidation.touched.merchantId ? onboardValidation.errors.merchantId : null} />
+                </div>
+                <div>
+                  <input type="text" placeholder="Business Name" value={onboardingForm.name} aria-label="Business Name" aria-describedby="mo-name-error"
+                    onChange={e => { setOnboardingForm({ ...onboardingForm, name: e.target.value }); onboardValidation.validateField('name', e.target.value); }}
+                    onBlur={e => onboardValidation.validateField('name', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${onboardValidation.touched.name && onboardValidation.errors.name ? 'border-red-500' : ''}`} />
+                  <FieldError id="mo-name-error" error={onboardValidation.touched.name ? onboardValidation.errors.name : null} />
+                </div>
               </div>
               <div className="grid grid-cols-2 gap-4">
-                <select value={onboardingForm.businessType} aria-label="Business Type"
-                  onChange={e => setOnboardingForm({ ...onboardingForm, businessType: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500">
-                  <option value="grocery">Grocery Store</option>
-                  <option value="pharmacy">Pharmacy</option>
-                  <option value="hardware">Hardware Store</option>
-                  <option value="fuel_station">Fuel Station</option>
-                  <option value="clothing">Clothing Store</option>
-                  <option value="restaurant">Restaurant</option>
-                  <option value="transport">Transport</option>
-                  <option value="communication">Communication</option>
-                </select>
-                <input type="text" placeholder="Contact Information" value={onboardingForm.contactInfo} required aria-label="Contact Information"
-                  onChange={e => setOnboardingForm({ ...onboardingForm, contactInfo: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                <div>
+                  <select value={onboardingForm.businessType} aria-label="Business Type" aria-describedby="mo-businessType-error"
+                    onChange={e => { setOnboardingForm({ ...onboardingForm, businessType: e.target.value }); onboardValidation.validateField('businessType', e.target.value); }}
+                    onBlur={e => onboardValidation.validateField('businessType', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${onboardValidation.touched.businessType && onboardValidation.errors.businessType ? 'border-red-500' : ''}`}>
+                    <option value="grocery">Grocery Store</option>
+                    <option value="pharmacy">Pharmacy</option>
+                    <option value="hardware">Hardware Store</option>
+                    <option value="fuel_station">Fuel Station</option>
+                    <option value="clothing">Clothing Store</option>
+                    <option value="restaurant">Restaurant</option>
+                    <option value="transport">Transport</option>
+                    <option value="communication">Communication</option>
+                  </select>
+                  <FieldError id="mo-businessType-error" error={onboardValidation.touched.businessType ? onboardValidation.errors.businessType : null} />
+                </div>
+                <div>
+                  <input type="text" placeholder="Contact Information" value={onboardingForm.contactInfo} aria-label="Contact Information" aria-describedby="mo-contactInfo-error"
+                    onChange={e => { setOnboardingForm({ ...onboardingForm, contactInfo: e.target.value }); onboardValidation.validateField('contactInfo', e.target.value); }}
+                    onBlur={e => onboardValidation.validateField('contactInfo', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${onboardValidation.touched.contactInfo && onboardValidation.errors.contactInfo ? 'border-red-500' : ''}`} />
+                  <FieldError id="mo-contactInfo-error" error={onboardValidation.touched.contactInfo ? onboardValidation.errors.contactInfo : null} />
+                </div>
               </div>
               <div className="grid grid-cols-2 gap-4">
-                <input type="text" placeholder="Stellar Address" value={onboardingForm.stellarAddress} required aria-label="Stellar Address"
-                  onChange={e => setOnboardingForm({ ...onboardingForm, stellarAddress: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                <div>
+                  <input type="text" placeholder="Stellar Address" value={onboardingForm.stellarAddress} aria-label="Stellar Address" aria-describedby="mo-stellarAddress-error"
+                    onChange={e => { setOnboardingForm({ ...onboardingForm, stellarAddress: e.target.value }); onboardValidation.validateField('stellarAddress', e.target.value); }}
+                    onBlur={e => onboardValidation.validateField('stellarAddress', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${onboardValidation.touched.stellarAddress && onboardValidation.errors.stellarAddress ? 'border-red-500' : ''}`} />
+                  <FieldError id="mo-stellarAddress-error" error={onboardValidation.touched.stellarAddress ? onboardValidation.errors.stellarAddress : null} />
+                </div>
                 <input type="text" placeholder="Accepted Tokens" value={onboardingForm.acceptedTokens} aria-label="Accepted Tokens"
                   onChange={e => setOnboardingForm({ ...onboardingForm, acceptedTokens: e.target.value })}
                   className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" />
@@ -209,25 +263,45 @@ export const MerchantMap: React.FC<MerchantMapProps> = ({ merchantClient, config
               <div className="border-t pt-4">
                 <h3 className="font-semibold mb-2">Location Information</h3>
                 <div className="grid grid-cols-2 gap-4">
-                  <input type="number" step="any" placeholder="Latitude" value={onboardingForm.location.latitude} required aria-label="Latitude"
-                    onChange={e => setOnboardingForm({ ...onboardingForm, location: { ...onboardingForm.location, latitude: e.target.value } })}
-                    className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" />
-                  <input type="number" step="any" placeholder="Longitude" value={onboardingForm.location.longitude} required aria-label="Longitude"
-                    onChange={e => setOnboardingForm({ ...onboardingForm, location: { ...onboardingForm.location, longitude: e.target.value } })}
-                    className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                  <div>
+                    <input type="number" step="any" placeholder="Latitude" value={onboardingForm.location.latitude} aria-label="Latitude" aria-describedby="mo-latitude-error"
+                      onChange={e => { setOnboardingForm({ ...onboardingForm, location: { ...onboardingForm.location, latitude: e.target.value } }); onboardValidation.validateField('latitude', e.target.value); }}
+                      onBlur={e => onboardValidation.validateField('latitude', e.target.value)}
+                      className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${onboardValidation.touched.latitude && onboardValidation.errors.latitude ? 'border-red-500' : ''}`} />
+                    <FieldError id="mo-latitude-error" error={onboardValidation.touched.latitude ? onboardValidation.errors.latitude : null} />
+                  </div>
+                  <div>
+                    <input type="number" step="any" placeholder="Longitude" value={onboardingForm.location.longitude} aria-label="Longitude" aria-describedby="mo-longitude-error"
+                      onChange={e => { setOnboardingForm({ ...onboardingForm, location: { ...onboardingForm.location, longitude: e.target.value } }); onboardValidation.validateField('longitude', e.target.value); }}
+                      onBlur={e => onboardValidation.validateField('longitude', e.target.value)}
+                      className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${onboardValidation.touched.longitude && onboardValidation.errors.longitude ? 'border-red-500' : ''}`} />
+                    <FieldError id="mo-longitude-error" error={onboardValidation.touched.longitude ? onboardValidation.errors.longitude : null} />
+                  </div>
                 </div>
                 <div className="grid grid-cols-2 gap-4 mt-2">
-                  <input type="text" placeholder="Address" value={onboardingForm.location.address} required aria-label="Address"
-                    onChange={e => setOnboardingForm({ ...onboardingForm, location: { ...onboardingForm.location, address: e.target.value } })}
-                    className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" />
-                  <input type="text" placeholder="City" value={onboardingForm.location.city} required aria-label="City"
-                    onChange={e => setOnboardingForm({ ...onboardingForm, location: { ...onboardingForm.location, city: e.target.value } })}
-                    className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                  <div>
+                    <input type="text" placeholder="Address" value={onboardingForm.location.address} aria-label="Address" aria-describedby="mo-address-error"
+                      onChange={e => { setOnboardingForm({ ...onboardingForm, location: { ...onboardingForm.location, address: e.target.value } }); onboardValidation.validateField('address', e.target.value); }}
+                      onBlur={e => onboardValidation.validateField('address', e.target.value)}
+                      className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${onboardValidation.touched.address && onboardValidation.errors.address ? 'border-red-500' : ''}`} />
+                    <FieldError id="mo-address-error" error={onboardValidation.touched.address ? onboardValidation.errors.address : null} />
+                  </div>
+                  <div>
+                    <input type="text" placeholder="City" value={onboardingForm.location.city} aria-label="City" aria-describedby="mo-city-error"
+                      onChange={e => { setOnboardingForm({ ...onboardingForm, location: { ...onboardingForm.location, city: e.target.value } }); onboardValidation.validateField('city', e.target.value); }}
+                      onBlur={e => onboardValidation.validateField('city', e.target.value)}
+                      className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${onboardValidation.touched.city && onboardValidation.errors.city ? 'border-red-500' : ''}`} />
+                    <FieldError id="mo-city-error" error={onboardValidation.touched.city ? onboardValidation.errors.city : null} />
+                  </div>
                 </div>
                 <div className="grid grid-cols-2 gap-4 mt-2">
-                  <input type="text" placeholder="Country" value={onboardingForm.location.country} required aria-label="Country"
-                    onChange={e => setOnboardingForm({ ...onboardingForm, location: { ...onboardingForm.location, country: e.target.value } })}
-                    className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                  <div>
+                    <input type="text" placeholder="Country" value={onboardingForm.location.country} aria-label="Country" aria-describedby="mo-country-error"
+                      onChange={e => { setOnboardingForm({ ...onboardingForm, location: { ...onboardingForm.location, country: e.target.value } }); onboardValidation.validateField('country', e.target.value); }}
+                      onBlur={e => onboardValidation.validateField('country', e.target.value)}
+                      className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${onboardValidation.touched.country && onboardValidation.errors.country ? 'border-red-500' : ''}`} />
+                    <FieldError id="mo-country-error" error={onboardValidation.touched.country ? onboardValidation.errors.country : null} />
+                  </div>
                   <input type="text" placeholder="Postal Code" value={onboardingForm.location.postalCode} aria-label="Postal Code"
                     onChange={e => setOnboardingForm({ ...onboardingForm, location: { ...onboardingForm.location, postalCode: e.target.value } })}
                     className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" />

--- a/ui/src/components/TransferCard.tsx
+++ b/ui/src/components/TransferCard.tsx
@@ -1,6 +1,19 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { TransferClient, ConditionalTransfer, SpendingRule, NetworkConfig } from '../../sdk/src/types';
 import {
+  useFormValidation,
+  FieldError,
+  compose,
+  required,
+  identifier,
+  isPositiveNumber,
+  minValue,
+  tokenType,
+  futureDate,
+  minLength,
+  maxLength,
+} from '../validation';
+import {
   SkeletonList,
   StatusMessage,
   EmptyState,
@@ -39,6 +52,22 @@ export const TransferCard: React.FC<TransferCardProps> = ({ transferClient, conf
     transferId: '', beneficiaryKey: '', merchantId: '', amount: '', category: 'food', location: '',
   });
 
+  const createValidation = useFormValidation<typeof createForm>({
+    transferId: compose(required('Transfer ID'), identifier('Transfer ID')),
+    beneficiaryId: compose(required('Beneficiary ID'), identifier('Beneficiary ID')),
+    amount: compose(required('Amount'), isPositiveNumber('Amount'), minValue(1, 'Amount')),
+    token: compose(required('Token'), tokenType),
+    expiresAt: compose(required('Expiry Date'), futureDate('Expiry Date')),
+    purpose: compose(required('Purpose'), minLength(2, 'Purpose'), maxLength(200, 'Purpose')),
+  });
+
+  const spendValidation = useFormValidation<typeof spendForm>({
+    transferId: compose(required('Transfer ID'), identifier('Transfer ID')),
+    beneficiaryKey: required('Beneficiary Key'),
+    merchantId: compose(required('Merchant ID'), identifier('Merchant ID')),
+    amount: compose(required('Amount'), isPositiveNumber('Amount'), minValue(1, 'Amount')),
+  });
+
   const loadTransfers = useCallback(async () => {
     setListLoading(true);
     setListError(null);
@@ -56,6 +85,7 @@ export const TransferCard: React.FC<TransferCardProps> = ({ transferClient, conf
 
   const handleCreateTransfer = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!createValidation.validateAll(createForm as Record<keyof typeof createForm, string>)) return;
     setSubmitting(true);
     setSubmitStatus(null);
     try {
@@ -74,6 +104,7 @@ export const TransferCard: React.FC<TransferCardProps> = ({ transferClient, conf
       );
       setShowCreateForm(false);
       setCreateForm({ transferId: '', beneficiaryId: '', amount: '', token: 'XLM', expiresAt: '', purpose: '', rules: createForm.rules });
+      createValidation.reset();
       setSubmitStatus({ type: 'success', message: 'Conditional transfer created successfully.' });
       loadTransfers();
     } catch {
@@ -85,6 +116,7 @@ export const TransferCard: React.FC<TransferCardProps> = ({ transferClient, conf
 
   const handleSpend = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!spendValidation.validateAll(spendForm as Record<keyof typeof spendForm, string>)) return;
     setSubmitting(true);
     setSubmitStatus(null);
     try {
@@ -96,6 +128,7 @@ export const TransferCard: React.FC<TransferCardProps> = ({ transferClient, conf
         setSubmitStatus({ type: 'success', message: 'Payment processed successfully.' });
         setShowSpendForm(false);
         setSpendForm({ transferId: '', beneficiaryKey: '', merchantId: '', amount: '', category: 'food', location: '' });
+        spendValidation.reset();
         loadTransfers();
       } else {
         setSubmitStatus({ type: 'error', message: 'Payment rejected by spending rules.' });
@@ -178,32 +211,56 @@ export const TransferCard: React.FC<TransferCardProps> = ({ transferClient, conf
             <h2 className="text-xl font-semibold mb-4">Create Conditional Transfer</h2>
             <form onSubmit={handleCreateTransfer} className="space-y-4" aria-label="Create transfer form">
               <div className="grid grid-cols-2 gap-4">
-                <input type="text" placeholder="Transfer ID" value={createForm.transferId} required aria-label="Transfer ID"
-                  onChange={e => setCreateForm({ ...createForm, transferId: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" />
-                <input type="text" placeholder="Beneficiary ID" value={createForm.beneficiaryId} required aria-label="Beneficiary ID"
-                  onChange={e => setCreateForm({ ...createForm, beneficiaryId: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                <div>
+                  <input type="text" placeholder="Transfer ID" value={createForm.transferId} aria-label="Transfer ID" aria-describedby="ct-transferId-error"
+                    onChange={e => { setCreateForm({ ...createForm, transferId: e.target.value }); createValidation.validateField('transferId', e.target.value); }}
+                    onBlur={e => createValidation.validateField('transferId', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${createValidation.touched.transferId && createValidation.errors.transferId ? 'border-red-500' : ''}`} />
+                  <FieldError id="ct-transferId-error" error={createValidation.touched.transferId ? createValidation.errors.transferId : null} />
+                </div>
+                <div>
+                  <input type="text" placeholder="Beneficiary ID" value={createForm.beneficiaryId} aria-label="Beneficiary ID" aria-describedby="ct-beneficiaryId-error"
+                    onChange={e => { setCreateForm({ ...createForm, beneficiaryId: e.target.value }); createValidation.validateField('beneficiaryId', e.target.value); }}
+                    onBlur={e => createValidation.validateField('beneficiaryId', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${createValidation.touched.beneficiaryId && createValidation.errors.beneficiaryId ? 'border-red-500' : ''}`} />
+                  <FieldError id="ct-beneficiaryId-error" error={createValidation.touched.beneficiaryId ? createValidation.errors.beneficiaryId : null} />
+                </div>
               </div>
               <div className="grid grid-cols-2 gap-4">
-                <input type="number" placeholder="Amount" value={createForm.amount} required aria-label="Amount"
-                  onChange={e => setCreateForm({ ...createForm, amount: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" />
-                <select value={createForm.token} aria-label="Token"
-                  onChange={e => setCreateForm({ ...createForm, token: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500">
-                  <option value="XLM">XLM</option>
-                  <option value="USDC">USDC</option>
-                  <option value="EURT">EURT</option>
-                </select>
+                <div>
+                  <input type="number" placeholder="Amount" value={createForm.amount} aria-label="Amount" aria-describedby="ct-amount-error"
+                    onChange={e => { setCreateForm({ ...createForm, amount: e.target.value }); createValidation.validateField('amount', e.target.value); }}
+                    onBlur={e => createValidation.validateField('amount', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${createValidation.touched.amount && createValidation.errors.amount ? 'border-red-500' : ''}`} />
+                  <FieldError id="ct-amount-error" error={createValidation.touched.amount ? createValidation.errors.amount : null} />
+                </div>
+                <div>
+                  <select value={createForm.token} aria-label="Token" aria-describedby="ct-token-error"
+                    onChange={e => { setCreateForm({ ...createForm, token: e.target.value }); createValidation.validateField('token', e.target.value); }}
+                    onBlur={e => createValidation.validateField('token', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${createValidation.touched.token && createValidation.errors.token ? 'border-red-500' : ''}`}>
+                    <option value="XLM">XLM</option>
+                    <option value="USDC">USDC</option>
+                    <option value="EURT">EURT</option>
+                  </select>
+                  <FieldError id="ct-token-error" error={createValidation.touched.token ? createValidation.errors.token : null} />
+                </div>
               </div>
               <div className="grid grid-cols-2 gap-4">
-                <input type="datetime-local" value={createForm.expiresAt} required aria-label="Expiry Date"
-                  onChange={e => setCreateForm({ ...createForm, expiresAt: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" />
-                <input type="text" placeholder="Purpose" value={createForm.purpose} required aria-label="Purpose"
-                  onChange={e => setCreateForm({ ...createForm, purpose: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                <div>
+                  <input type="datetime-local" value={createForm.expiresAt} aria-label="Expiry Date" aria-describedby="ct-expiresAt-error"
+                    onChange={e => { setCreateForm({ ...createForm, expiresAt: e.target.value }); createValidation.validateField('expiresAt', e.target.value); }}
+                    onBlur={e => createValidation.validateField('expiresAt', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${createValidation.touched.expiresAt && createValidation.errors.expiresAt ? 'border-red-500' : ''}`} />
+                  <FieldError id="ct-expiresAt-error" error={createValidation.touched.expiresAt ? createValidation.errors.expiresAt : null} />
+                </div>
+                <div>
+                  <input type="text" placeholder="Purpose" value={createForm.purpose} aria-label="Purpose" aria-describedby="ct-purpose-error"
+                    onChange={e => { setCreateForm({ ...createForm, purpose: e.target.value }); createValidation.validateField('purpose', e.target.value); }}
+                    onBlur={e => createValidation.validateField('purpose', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${createValidation.touched.purpose && createValidation.errors.purpose ? 'border-red-500' : ''}`} />
+                  <FieldError id="ct-purpose-error" error={createValidation.touched.purpose ? createValidation.errors.purpose : null} />
+                </div>
               </div>
               <div className="flex gap-3">
                 <LoadingButton type="submit" loading={submitting} loadingLabel="Creating…"
@@ -225,20 +282,36 @@ export const TransferCard: React.FC<TransferCardProps> = ({ transferClient, conf
             <h2 className="text-xl font-semibold mb-4">Process Payment</h2>
             <form onSubmit={handleSpend} className="space-y-4" aria-label="Process payment form">
               <div className="grid grid-cols-2 gap-4">
-                <input type="text" placeholder="Transfer ID" value={spendForm.transferId} required aria-label="Transfer ID"
-                  onChange={e => setSpendForm({ ...spendForm, transferId: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-green-500" />
-                <input type="password" placeholder="Beneficiary Key" value={spendForm.beneficiaryKey} required aria-label="Beneficiary Key"
-                  onChange={e => setSpendForm({ ...spendForm, beneficiaryKey: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-green-500" />
+                <div>
+                  <input type="text" placeholder="Transfer ID" value={spendForm.transferId} aria-label="Transfer ID" aria-describedby="sp-transferId-error"
+                    onChange={e => { setSpendForm({ ...spendForm, transferId: e.target.value }); spendValidation.validateField('transferId', e.target.value); }}
+                    onBlur={e => spendValidation.validateField('transferId', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-green-500 ${spendValidation.touched.transferId && spendValidation.errors.transferId ? 'border-red-500' : ''}`} />
+                  <FieldError id="sp-transferId-error" error={spendValidation.touched.transferId ? spendValidation.errors.transferId : null} />
+                </div>
+                <div>
+                  <input type="password" placeholder="Beneficiary Key" value={spendForm.beneficiaryKey} aria-label="Beneficiary Key" aria-describedby="sp-beneficiaryKey-error"
+                    onChange={e => { setSpendForm({ ...spendForm, beneficiaryKey: e.target.value }); spendValidation.validateField('beneficiaryKey', e.target.value); }}
+                    onBlur={e => spendValidation.validateField('beneficiaryKey', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-green-500 ${spendValidation.touched.beneficiaryKey && spendValidation.errors.beneficiaryKey ? 'border-red-500' : ''}`} />
+                  <FieldError id="sp-beneficiaryKey-error" error={spendValidation.touched.beneficiaryKey ? spendValidation.errors.beneficiaryKey : null} />
+                </div>
               </div>
               <div className="grid grid-cols-2 gap-4">
-                <input type="text" placeholder="Merchant ID" value={spendForm.merchantId} required aria-label="Merchant ID"
-                  onChange={e => setSpendForm({ ...spendForm, merchantId: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-green-500" />
-                <input type="number" placeholder="Amount" value={spendForm.amount} required aria-label="Amount"
-                  onChange={e => setSpendForm({ ...spendForm, amount: e.target.value })}
-                  className="px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-green-500" />
+                <div>
+                  <input type="text" placeholder="Merchant ID" value={spendForm.merchantId} aria-label="Merchant ID" aria-describedby="sp-merchantId-error"
+                    onChange={e => { setSpendForm({ ...spendForm, merchantId: e.target.value }); spendValidation.validateField('merchantId', e.target.value); }}
+                    onBlur={e => spendValidation.validateField('merchantId', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-green-500 ${spendValidation.touched.merchantId && spendValidation.errors.merchantId ? 'border-red-500' : ''}`} />
+                  <FieldError id="sp-merchantId-error" error={spendValidation.touched.merchantId ? spendValidation.errors.merchantId : null} />
+                </div>
+                <div>
+                  <input type="number" placeholder="Amount" value={spendForm.amount} aria-label="Amount" aria-describedby="sp-amount-error"
+                    onChange={e => { setSpendForm({ ...spendForm, amount: e.target.value }); spendValidation.validateField('amount', e.target.value); }}
+                    onBlur={e => spendValidation.validateField('amount', e.target.value)}
+                    className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-green-500 ${spendValidation.touched.amount && spendValidation.errors.amount ? 'border-red-500' : ''}`} />
+                  <FieldError id="sp-amount-error" error={spendValidation.touched.amount ? spendValidation.errors.amount : null} />
+                </div>
               </div>
               <div className="grid grid-cols-2 gap-4">
                 <select value={spendForm.category} aria-label="Category"

--- a/ui/src/validation/FieldError.tsx
+++ b/ui/src/validation/FieldError.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+interface FieldErrorProps {
+  error?: string | null;
+  id?: string;
+}
+
+/**
+ * Renders an inline validation error message below a form field.
+ * Uses role="alert" so screen readers announce it immediately.
+ */
+export const FieldError: React.FC<FieldErrorProps> = ({ error, id }) => {
+  if (!error) return null;
+  return (
+    <p
+      id={id}
+      role="alert"
+      aria-live="polite"
+      className="mt-1 text-sm text-red-600"
+    >
+      {error}
+    </p>
+  );
+};

--- a/ui/src/validation/index.ts
+++ b/ui/src/validation/index.ts
@@ -1,0 +1,3 @@
+export * from './validators';
+export * from './useFormValidation';
+export { FieldError } from './FieldError';

--- a/ui/src/validation/useFormValidation.ts
+++ b/ui/src/validation/useFormValidation.ts
@@ -1,0 +1,77 @@
+import { useState, useCallback, useRef } from 'react';
+import { Validator } from './validators';
+
+export type FieldErrors<T> = Partial<Record<keyof T, string>>;
+export type FieldTouched<T> = Partial<Record<keyof T, boolean>>;
+export type FieldRules<T> = Partial<Record<keyof T, Validator>>;
+
+export interface UseFormValidationReturn<T> {
+  errors: FieldErrors<T>;
+  touched: FieldTouched<T>;
+  /** Validate a single field and mark it touched */
+  validateField: (name: keyof T, value: string) => string | null;
+  /** Validate all fields at once (for submit). Returns true if valid. */
+  validateAll: (values: Record<keyof T, string>) => boolean;
+  /** Mark a field as touched (on blur) */
+  touchField: (name: keyof T) => void;
+  /** Clear all errors and touched state */
+  reset: () => void;
+  /** Whether the form has any errors */
+  hasErrors: boolean;
+}
+
+/**
+ * Minimal form validation hook.
+ * Pass a rules map of { fieldName: Validator } and it tracks errors + touched state.
+ */
+export function useFormValidation<T extends Record<string, string>>(
+  rules: FieldRules<T>
+): UseFormValidationReturn<T> {
+  const [errors, setErrors] = useState<FieldErrors<T>>({});
+  const [touched, setTouched] = useState<FieldTouched<T>>({});
+  // Keep rules in a ref so callers don't need to memoize
+  const rulesRef = useRef(rules);
+  rulesRef.current = rules;
+
+  const validateField = useCallback((name: keyof T, value: string): string | null => {
+    const validator = rulesRef.current[name];
+    const error = validator ? validator(value) : null;
+    setErrors((prev) => ({ ...prev, [name]: error ?? undefined }));
+    setTouched((prev) => ({ ...prev, [name]: true }));
+    return error;
+  }, []);
+
+  const touchField = useCallback((name: keyof T) => {
+    setTouched((prev) => ({ ...prev, [name]: true }));
+  }, []);
+
+  const validateAll = useCallback((values: Record<keyof T, string>): boolean => {
+    const newErrors: FieldErrors<T> = {};
+    const newTouched: FieldTouched<T> = {};
+    let valid = true;
+
+    for (const name of Object.keys(rulesRef.current) as (keyof T)[]) {
+      const validator = rulesRef.current[name];
+      if (!validator) continue;
+      const error = validator(values[name] ?? '');
+      newTouched[name] = true;
+      if (error) {
+        newErrors[name] = error;
+        valid = false;
+      }
+    }
+
+    setErrors(newErrors);
+    setTouched(newTouched);
+    return valid;
+  }, []);
+
+  const reset = useCallback(() => {
+    setErrors({});
+    setTouched({});
+  }, []);
+
+  const hasErrors = Object.values(errors).some(Boolean);
+
+  return { errors, touched, validateField, validateAll, touchField, reset, hasErrors };
+}

--- a/ui/src/validation/validators.ts
+++ b/ui/src/validation/validators.ts
@@ -1,0 +1,184 @@
+/**
+ * Core validation functions for the Stellar Disaster Relief platform.
+ * Each validator returns null on success or an error message string on failure.
+ */
+
+export type Validator<T = string> = (value: T) => string | null;
+
+// ─── Primitives ────────────────────────────────────────────────────────────────
+
+export const required = (label = 'This field'): Validator => (value) => {
+  if (value === null || value === undefined) return `${label} is required.`;
+  if (typeof value === 'string' && value.trim() === '') return `${label} is required.`;
+  return null;
+};
+
+export const minLength =
+  (min: number, label = 'This field'): Validator =>
+  (value) => {
+    if (!value) return null; // let required() handle empty
+    if (value.trim().length < min) return `${label} must be at least ${min} characters.`;
+    return null;
+  };
+
+export const maxLength =
+  (max: number, label = 'This field'): Validator =>
+  (value) => {
+    if (!value) return null;
+    if (value.trim().length > max) return `${label} must be at most ${max} characters.`;
+    return null;
+  };
+
+export const pattern =
+  (regex: RegExp, message: string): Validator =>
+  (value) => {
+    if (!value || value.trim() === '') return null;
+    if (!regex.test(value.trim())) return message;
+    return null;
+  };
+
+// ─── Numeric ───────────────────────────────────────────────────────────────────
+
+export const isPositiveNumber =
+  (label = 'Amount'): Validator =>
+  (value) => {
+    if (!value || value.trim() === '') return null;
+    const n = Number(value.trim());
+    if (isNaN(n) || !isFinite(n)) return `${label} must be a valid number.`;
+    if (n <= 0) return `${label} must be greater than 0.`;
+    return null;
+  };
+
+export const isInteger =
+  (label = 'Value'): Validator =>
+  (value) => {
+    if (!value || value.trim() === '') return null;
+    if (!/^-?\d+$/.test(value.trim())) return `${label} must be a whole number.`;
+    return null;
+  };
+
+export const minValue =
+  (min: number, label = 'Value'): Validator =>
+  (value) => {
+    if (!value || value.trim() === '') return null;
+    const n = Number(value.trim());
+    if (isNaN(n)) return null; // let isPositiveNumber handle
+    if (n < min) return `${label} must be at least ${min}.`;
+    return null;
+  };
+
+export const maxValue =
+  (max: number, label = 'Value'): Validator =>
+  (value) => {
+    if (!value || value.trim() === '') return null;
+    const n = Number(value.trim());
+    if (isNaN(n)) return null;
+    if (n > max) return `${label} must be at most ${max}.`;
+    return null;
+  };
+
+// ─── Domain-specific ───────────────────────────────────────────────────────────
+
+/** Stellar public key: starts with G, 56 alphanumeric chars */
+export const stellarAddress: Validator = (value) => {
+  if (!value || value.trim() === '') return null;
+  const v = value.trim();
+  if (!/^G[A-Z2-7]{55}$/.test(v))
+    return 'Stellar address must start with G and be 56 characters (A-Z, 2-7).';
+  return null;
+};
+
+export const DISASTER_TYPES = ['earthquake', 'flood', 'hurricane', 'wildfire', 'drought'] as const;
+export type DisasterType = (typeof DISASTER_TYPES)[number];
+
+export const disasterType: Validator = (value) => {
+  if (!value || value.trim() === '') return null;
+  if (!(DISASTER_TYPES as readonly string[]).includes(value.trim()))
+    return `Disaster type must be one of: ${DISASTER_TYPES.join(', ')}.`;
+  return null;
+};
+
+export const BUSINESS_TYPES = [
+  'grocery', 'pharmacy', 'hardware', 'fuel_station',
+  'clothing', 'restaurant', 'transport', 'communication',
+] as const;
+export type BusinessType = (typeof BUSINESS_TYPES)[number];
+
+export const businessType: Validator = (value) => {
+  if (!value || value.trim() === '') return null;
+  if (!(BUSINESS_TYPES as readonly string[]).includes(value.trim()))
+    return `Business type must be one of: ${BUSINESS_TYPES.join(', ')}.`;
+  return null;
+};
+
+export const TOKEN_TYPES = ['XLM', 'USDC', 'EURT'] as const;
+export type TokenType = (typeof TOKEN_TYPES)[number];
+
+export const tokenType: Validator = (value) => {
+  if (!value || value.trim() === '') return null;
+  if (!(TOKEN_TYPES as readonly string[]).includes(value.trim()))
+    return `Token must be one of: ${TOKEN_TYPES.join(', ')}.`;
+  return null;
+};
+
+/** Identifier: alphanumeric, underscores, hyphens, 1-64 chars */
+export const identifier =
+  (label = 'ID'): Validator =>
+  (value) => {
+    if (!value || value.trim() === '') return null;
+    if (!/^[a-zA-Z0-9_-]{1,64}$/.test(value.trim()))
+      return `${label} must be 1-64 characters (letters, numbers, underscores, hyphens).`;
+    return null;
+  };
+
+/** Future datetime: value must be a datetime-local string in the future */
+export const futureDate =
+  (label = 'Date'): Validator =>
+  (value) => {
+    if (!value || value.trim() === '') return null;
+    const ts = new Date(value.trim()).getTime();
+    if (isNaN(ts)) return `${label} must be a valid date.`;
+    if (ts <= Date.now()) return `${label} must be in the future.`;
+    return null;
+  };
+
+/** Latitude: -90 to 90 */
+export const latitude: Validator = (value) => {
+  if (!value || value.trim() === '') return null;
+  const n = Number(value.trim());
+  if (isNaN(n)) return 'Latitude must be a valid number.';
+  if (n < -90 || n > 90) return 'Latitude must be between -90 and 90.';
+  return null;
+};
+
+/** Longitude: -180 to 180 */
+export const longitude: Validator = (value) => {
+  if (!value || value.trim() === '') return null;
+  const n = Number(value.trim());
+  if (isNaN(n)) return 'Longitude must be a valid number.';
+  if (n < -180 || n > 180) return 'Longitude must be between -180 and 180.';
+  return null;
+};
+
+/** Comma-separated list: at least one non-empty item */
+export const commaSeparatedRequired =
+  (label = 'Field'): Validator =>
+  (value) => {
+    if (!value || value.trim() === '') return null;
+    const items = value.split(',').map((s) => s.trim()).filter(Boolean);
+    if (items.length === 0) return `${label} must contain at least one value.`;
+    return null;
+  };
+
+// ─── Composer ──────────────────────────────────────────────────────────────────
+
+/** Run validators in order, return first error or null */
+export const compose =
+  <T = string>(...validators: Validator<T>[]): Validator<T> =>
+  (value) => {
+    for (const v of validators) {
+      const err = v(value);
+      if (err) return err;
+    }
+    return null;
+  };


### PR DESCRIPTION
## Summary

Closes #41

Implements comprehensive client-side validation across all four application forms using a consistent, reusable, type-safe validation architecture.

---

## What Changed

### New: `ui/src/validation/`

| File | Purpose |
|------|---------|
| `validators.ts` | Pure validator functions — composable, type-safe, zero dependencies |
| `useFormValidation.ts` | React hook managing per-field errors + touched state |
| `FieldError.tsx` | Accessible inline error component (`role="alert"`, `aria-live`) |
| `index.ts` | Barrel export |

**Validators implemented:** `required`, `minLength`, `maxLength`, `isPositiveNumber`, `isInteger`, `minValue`, `maxValue`, `stellarAddress` (G + 56 chars), `disasterType`, `businessType`, `tokenType`, `identifier`, `futureDate`, `latitude`, `longitude`, `commaSeparatedRequired`, `compose`

### Updated: All 4 Form Components

| Component | Forms Validated |
|-----------|----------------|
| `EmergencyDeployer` | Create Fund, Rapid Response |
| `BeneficiaryRegistration` | Register Beneficiary, Verify Identity |
| `TransferCard` | Create Transfer, Process Payment |
| `MerchantMap` | Merchant Onboarding (incl. GPS coordinates) |

### New: `ui/src/__tests__/validators.test.ts`
77 unit tests covering every validator with valid inputs, invalid inputs, boundary conditions, empty values, whitespace-only strings, malformed data, and compose chains.

---

## Validation Behaviour

- **Real-time feedback** — errors appear on `onBlur` per field
- **Submit guard** — `validateAll()` runs on submit; invalid forms are blocked before any API call
- **Inline errors** — `<FieldError>` renders below each field with `role="alert"` and `aria-describedby` linking input → error
- **Red border** — invalid touched fields get `border-red-500`
- **State reset** — errors and touched state cleared on successful submission
- **Accessibility** — screen-reader compatible via `aria-live="polite"` and `aria-describedby`

---

## Domain Rules Enforced

- Stellar wallet addresses: must start with `G`, exactly 56 chars (A–Z, 2–7)
- Disaster types: `earthquake | flood | hurricane | wildfire | drought`
- Business types: `grocery | pharmacy | hardware | fuel_station | clothing | restaurant | transport | communication`
- Token types: `XLM | USDC | EURT`
- Identifiers: alphanumeric + `_-`, 1–64 chars
- Expiry dates: must be in the future
- Latitude: −90 to 90; Longitude: −180 to 180
- Amounts: positive numbers > 0
- Family size: integer ≥ 1
- Comma-separated fields: at least one non-empty item

---

## Testing

```
Tests: 77 passed, 77 total
```

```bash
npx jest --testPathPattern="validators.test" --no-coverage
```

All tests are deterministic and CI-safe (no DOM, no React renderer required for the validator unit tests).